### PR TITLE
Render a different icon depending on activity type

### DIFF
--- a/src/Card.js
+++ b/src/Card.js
@@ -6,12 +6,12 @@ class Card extends React.Component {
   render() {
     const activityTitle = this.props.activityTitle || "";
     return (
-      <article class="background-card" id={activityTitle.toLowerCase()}>
+      <article className="background-card" id={activityTitle.toLowerCase()}>
         <Icon />
-        <div class="card-body">
-          <p class="activity-titles">{activityTitle}</p>
-          <p class="time">{this.props.time}hrs</p>
-          <p class="previous-time">Previous {this.props.previousTime}hrs</p>
+        <div className="card-body">
+          <p className="activity-titles">{activityTitle}</p>
+          <p className="time">{this.props.time}hrs</p>
+          <p className="previous-time">Previous {this.props.previousTime}hrs</p>
         </div>
       </article>
     );

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,13 +1,20 @@
 import React from "react";
-import { ReactComponent as Icon } from "./images/icon-work.svg";
+import { ReactComponent as WorkIcon } from "./images/icon-work.svg";
+import { ReactComponent as PlayIcon } from "./images/icon-play.svg";
 import "./Card.css";
 
+// depending on activity type, render a different icon
+const icons = {
+  work: <WorkIcon/>,
+  play: <PlayIcon/>,
+}
 class Card extends React.Component {
   render() {
     const activityTitle = this.props.activityTitle || "";
     return (
       <article className="background-card" id={activityTitle.toLowerCase()}>
-        <Icon />
+        {/* get an icon for the activity */}
+        {icons[activityTitle.toLowerCase()]}
         <div className="card-body">
           <p className="activity-titles">{activityTitle}</p>
           <p className="time">{this.props.time}hrs</p>


### PR DESCRIPTION
Hey Alex, this is one of the ways to render a different icon depending on the type of activity. I added 2 icons for now: Work and Play, and you can add the rest.

I've also updated all `class` properties in `Card.js` to `className` since DevTools were complaining about that.

Thanks,
Anna